### PR TITLE
QOL: fix wheat-seed logo on title screen when using mod menu.

### DIFF
--- a/src/main/java/me/duncanruns/fsgmod/mixin/TitleScreenMixin.java
+++ b/src/main/java/me/duncanruns/fsgmod/mixin/TitleScreenMixin.java
@@ -30,13 +30,17 @@ public abstract class TitleScreenMixin extends Screen {
     @Unique
     private final int seedOffset = RANDOM.nextInt(2); // If you found this, yes, it's making the seed render one pixel off at random.
 
+    @Unique
+    private ButtonWidget fsgConfigButton;
+
     protected TitleScreenMixin(Text title) {
         super(title);
     }
 
     @Inject(method = "init", at = @At("TAIL"))
     private void init(CallbackInfo info) {
-        this.addButton(new ButtonWidget(this.width / 2 - 124, this.height / 4 + 48 + 24, 20, 20, new LiteralText(""), (b) -> {
+        // Save the button instance to the variable instead of just adding it
+        this.fsgConfigButton = this.addButton(new ButtonWidget(this.width / 2 - 124, this.height / 4 + 48 + 24, 20, 20, new LiteralText(""), (b) -> {
             assert client != null;
             client.openScreen(new ConfigScreen());
         }));
@@ -44,9 +48,16 @@ public abstract class TitleScreenMixin extends Screen {
 
     @Inject(method = "render", at = @At("TAIL"))
     private void wheatSeedsOverlay(MatrixStack matrices, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+        if (this.fsgConfigButton == null) return; // Safety check to prevent crashes
+
         assert this.client != null;
         this.client.getTextureManager().bindTexture(BUTTON_IMAGE);
-        drawTexture(matrices, this.width / 2 - 124 + 1 + (isMinceraft ? RANDOM.nextInt(2) : seedOffset), this.height / 4 + 48 + 2 + 24, 0.0F, 0.0F, 16, 16, 16, 16);
+        
+        // Dynamically grab the button's X and Y coordinates so the texture tracks the box
+        int iconX = this.fsgConfigButton.x + 1 + (isMinceraft ? RANDOM.nextInt(2) : seedOffset);
+        int iconY = this.fsgConfigButton.y + 2;
+        
+        drawTexture(matrices, iconX, iconY, 0.0F, 0.0F, 16, 16, 16, 16);
     }
 
 }


### PR DESCRIPTION
Using mod menu displaced the wheat-seeds logo because of hardcoded values.